### PR TITLE
Document testing, change meck dependency to one that supports R18

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ startup on the command line or in an application config file:
           > myapp.config
        $ erl -pa ebin deps/*/ebin -config myapp.config -s folsom
 
+The folsom tests can be run using rebar:
+
+       $ rebar eunit
+       
 #### Metrics API
 
 folsom_metrics.erl is the API module you will need to use most of the time.

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {deps, [
     {bear, ".*", {git, "https://git-wip-us.apache.org/repos/asf/couchdb-bear.git", {tag, "0.8.1"}}},
-    {meck, ".*", {git, "https://git-wip-us.apache.org/repos/asf/couchdb-meck.git", {tag, "0.8.2"}}}
+    {meck, ".*", {git, "https://github.com/eproxus/meck.git", {tag, "0.8.4"}}}
 ]}.
 
 {erl_opts, [debug_info]}.


### PR DESCRIPTION
Update folsom rebar.config to use a more recent version of meck (0.8.4), compatible with Erlang 18

Bugzid: 64114
